### PR TITLE
Fixed props key was spread into JSX FitImage

### DIFF
--- a/src/lib/renderRules.js
+++ b/src/lib/renderRules.js
@@ -293,7 +293,6 @@ const renderRules = {
 
     const imageProps = {
       indicator: true,
-      key: node.key,
       style: styles._VIEW_SAFE_image,
       source: {
         uri: show === true ? src : `${defaultImageHandler}${src}`,


### PR DESCRIPTION


Hi,

With the last version of react-native (0.75.4), the package display a warning for a deprecated code :
```
 ERROR  Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, indicator: ..., style: ..., source: ..., accessible: ..., accessibilityLabel: ...};
  <FitImage {...props} />
React keys must be passed directly to JSX without using spread:
  let props = {indicator: ..., style: ..., source: ..., accessible: ..., accessibilityLabel: ...};
  <FitImage key={someKey} {...props} />
```
So I create this PR to fix it. As you can see, it’s really a light commit.

This PR work with last react-native version and previous one.

Thanks for reading.
